### PR TITLE
Allow Docker-in-Docker for reproducible builds. Use fixed versions within the Dockerfile, as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Resources:
 Build the Docker images for local testing:
 
 ```
-docker buildx build --output type=docker ./resources/smart-contracts-rust -t multiversx/devcontainer-smart-contracts-rust:next -f ./resources/smart-contracts-rust/Dockerfile
+docker build ./resources/smart-contracts-rust -t multiversx/devcontainer-smart-contracts-rust:next -f ./resources/smart-contracts-rust/Dockerfile
 ```
 
 ### Test the templates
@@ -49,7 +49,8 @@ Then, in VSCode, launch the command `Dev Containers: Rebuild and Reopen in Conta
 Build and publish the Docker images:
 
 ```
-docker buildx build --push --platform=linux/amd64 ./resources/smart-contracts-rust -t multiversx/devcontainer-smart-contracts-rust:next -f ./resources/smart-contracts-rust/Dockerfile
+docker build ./resources/smart-contracts-rust -t multiversx/devcontainer-smart-contracts-rust:next -f ./resources/smart-contracts-rust/Dockerfile
+docker push multiversx/devcontainer-smart-contracts-rust:next
 ```
 
 ### Publish templates

--- a/resources/smart-contracts-rust/Dockerfile
+++ b/resources/smart-contracts-rust/Dockerfile
@@ -4,6 +4,11 @@ ARG USERNAME=developer
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
+ARG VERSION_MXPY="v6.1.3"
+ARG VERSION_RUST="nightly-2022-10-16"
+ARG VERSION_WASM_OPT="version_105"
+ARG VERSION_VMTOOLS="v1.4.60"
+
 # Create the user
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
@@ -31,14 +36,14 @@ ENV MULTIVERSX=/home/${USERNAME}/multiversx-sdk
 RUN mkdir ${MULTIVERSX}
 
 # Install mxpy
-RUN pip3 install --no-cache-dir https://github.com/multiversx/mx-sdk-py-cli/archive/refs/heads/devcontainer.zip
+RUN pip3 install --no-cache-dir https://github.com/multiversx/mx-sdk-py-cli/archive/refs/tags/${VERSION_MXPY}.zip
 ENV PATH="${MULTIVERSX}:${PATH}"
 COPY "mxpy" "${MULTIVERSX}/mxpy"
 
 # Install rust and other tools
-RUN mxpy deps install rust && rm -rf ${MULTIVERSX}/vendor-rust/registry/*
-RUN mxpy deps install wasm-opt && rm ${MULTIVERSX}/*.tar.gz
-RUN mxpy deps install vmtools && rm ${MULTIVERSX}/*.tar.gz && sudo rm -rf ${MULTIVERSX}/golang
+RUN mxpy deps install rust --tag=${VERSION_RUST} && rm -rf ${MULTIVERSX}/vendor-rust/registry/*
+RUN mxpy deps install wasm-opt --tag=${VERSION_WASM_OPT} && rm ${MULTIVERSX}/*.tar.gz
+RUN mxpy deps install vmtools --tag=${VERSION_VMTOOLS} && rm ${MULTIVERSX}/*.tar.gz && sudo rm -rf ${MULTIVERSX}/golang
 
 ENV PATH="${MULTIVERSX}/vendor-rust/bin:${MULTIVERSX}/vmtools:${PATH}"
 ENV CARGO_HOME="${MULTIVERSX}/vendor-rust"

--- a/src/smart-contracts-rust/.devcontainer/devcontainer.json
+++ b/src/smart-contracts-rust/.devcontainer/devcontainer.json
@@ -2,7 +2,13 @@
 	"name": "MultiversX Smart Contracts",
 	"image": "multiversx/devcontainer-smart-contracts-rust:next",
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"version": "latest",
+			"moby": false,
+			"installDockerBuildx": false
+		}
+	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Run commands after the container is created.

--- a/src/smart-contracts-rust/devcontainer-template.json
+++ b/src/smart-contracts-rust/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "smart-contracts-rust",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "name": "MultiversX: Smart Contracts Development (Rust)",
     "description": "Develop smart contracts for MultiversX. Includes Rust, mxpy, VSCode extensions etc.",
     "documentationURL": "https://github.com/multiversx/mx-template-devcontainers/blob/main/src/smart-contracts-rust",


### PR DESCRIPTION
 - Install `docker-in-docker` feature, to allow mxpy's `reproducible-build` command (which relies on Docker)
 - Use fixed versions for `mxpy`, `rust`, `wasm-opt`, as well.

:whale: 